### PR TITLE
Some python2/3 compatability improvements

### DIFF
--- a/magma/README.md
+++ b/magma/README.md
@@ -4,6 +4,7 @@ Add magma to your PYTHONPATH
 
 ```
 export PYTHONPATH=$PYTHONPATH:<YOUR_PATH>/CS448H/magma
+pip install six  # For python2/3 compatability
 ```
 
 Magma uses a build system based on `fabricate`.

--- a/magma/magma/array.py
+++ b/magma/magma/array.py
@@ -151,6 +151,7 @@ class ArrayType(Type):
         return array(*ts)
 
 class ArrayKind(Kind):
+    __hash__ = Kind.__hash__
     def __init__(cls, name, bases, dct):
         Kind.__init__( cls, name, bases, dct)
 

--- a/magma/magma/bit.py
+++ b/magma/magma/bit.py
@@ -78,6 +78,7 @@ class BitType(Type):
 
 
 class BitKind(Kind):
+    __hash__ = Kind.__hash__
 
     def __init__(cls, name, bases, dct):
         Kind.__init__( cls, name, bases, dct)

--- a/magma/magma/circuit.py
+++ b/magma/magma/circuit.py
@@ -1,5 +1,6 @@
 from magma.interface import *
 from magma.wire import *
+from six import with_metaclass
 
 __all__  = ['CircuitType']
 
@@ -62,8 +63,7 @@ class CircuitKind(type):
 #
 # Abstract base class for circuits
 #
-class _CircuitType(object):
-    __metaclass__ = CircuitKind
+class _CircuitType(with_metaclass(CircuitKind, object)):
 
     def __init__(self, *largs, **kwargs):
         self.largs = largs
@@ -296,8 +296,8 @@ class DefineCircuitKind(CircuitKind):
             elif orientation == 'horizontal':
                 x += dx
 
-class Circuit(CircuitType):
-    __metaclass__ = DefineCircuitKind
+class Circuit(with_metaclass(DefineCircuitKind, CircuitType)):
+    pass
 
 
 # DefineCircuit Factory

--- a/magma/magma/ref.py
+++ b/magma/magma/ref.py
@@ -1,3 +1,4 @@
+import sys
 __all__ = ['AnonRef', 'InstRef', 'DefnRef', 'ArrayRef', 'TupleRef']
 
 class Ref:
@@ -22,6 +23,8 @@ class InstRef(Ref):
 
     def qualifiedname(self, sep='.'):
         name = self.name
+        if sys.version_info > (3,):
+            long = int  # long remove in py3+
         if isinstance(self.name, (int, long)):
             # Hack, Hack, Hack
             if sep == '.':

--- a/magma/magma/ref.py
+++ b/magma/magma/ref.py
@@ -1,4 +1,7 @@
 import sys
+if sys.version_info > (3,):
+    long = int  # long remove in py3+
+
 __all__ = ['AnonRef', 'InstRef', 'DefnRef', 'ArrayRef', 'TupleRef']
 
 class Ref:
@@ -23,8 +26,6 @@ class InstRef(Ref):
 
     def qualifiedname(self, sep='.'):
         name = self.name
-        if sys.version_info > (3,):
-            long = int  # long remove in py3+
         if isinstance(self.name, (int, long)):
             # Hack, Hack, Hack
             if sep == '.':

--- a/magma/magma/ref.py
+++ b/magma/magma/ref.py
@@ -1,6 +1,4 @@
 import sys
-if sys.version_info > (3,):
-    long = int  # long remove in py3+
 
 __all__ = ['AnonRef', 'InstRef', 'DefnRef', 'ArrayRef', 'TupleRef']
 
@@ -26,7 +24,11 @@ class InstRef(Ref):
 
     def qualifiedname(self, sep='.'):
         name = self.name
-        if isinstance(self.name, (int, long)):
+        if sys.version_info > (3,):
+            _typs = (int, )  # long removed in python3
+        else:
+            _typs = (int, long)
+        if isinstance(self.name, _typs):
             # Hack, Hack, Hack
             if sep == '.':
                 return str(self.inst) + '[%d]' % self.name

--- a/magma/magma/t.py
+++ b/magma/magma/t.py
@@ -85,12 +85,11 @@ class Type(object):
 
 
 class Kind(type):
+    __hash__ = type.__hash__
     def __init__(cls, name, bases, dct):
         type.__init__( cls, name, bases, dct)
     def __eq__(cls, rhs):
         return not (cls != rhs)
-    def __hash__(cls):
-        return id(cls)
     def __ne__(cls, rhs):
         return not (cls == rhs)
     def __repr__(cls):

--- a/magma/magma/t.py
+++ b/magma/magma/t.py
@@ -89,6 +89,8 @@ class Kind(type):
         type.__init__( cls, name, bases, dct)
     def __eq__(cls, rhs):
         return not (cls != rhs)
+    def __hash__(cls):
+        return id(cls)
     def __ne__(cls, rhs):
         return not (cls == rhs)
     def __repr__(cls):


### PR DESCRIPTION
defining `__eq__` in Python 3 prevents `__hash__` from being inherited, updated it to explicitly use the parent class `__hash__` as per docs:
- https://docs.python.org/3.1/reference/datamodel.html#object.__hash__
  > If a class that overrides `__eq__()` needs to retain the implementation of `__hash__()` from a parent class, the interpreter must be told this explicitly by setting `__hash__ = <ParentClass>.__hash__`. Otherwise the inheritance of `__hash__()` will be blocked, just as if `__hash__` had been explicitly set to None.

Python 3 changed the syntax for specifying a metaclass:
- https://www.python.org/dev/peps/pep-3115/
  >  In the new model, the syntax for specifying a metaclass is via a
     keyword argument in the list of base classes:

       class Foo(base1, base2, metaclass=mymeta):
         ...
I used the `six` library which provides a convenient wrapper `with_metaclass` that supports Python 2 and 3.

Changes like these probably need to occur in more places but these ones popped up in my current flow.